### PR TITLE
All passing Fernet to EncryptedCookieStorage

### DIFF
--- a/aiohttp_session/cookie_storage.py
+++ b/aiohttp_session/cookie_storage.py
@@ -21,11 +21,14 @@ class EncryptedCookieStorage(AbstractStorage):
                          httponly=httponly,
                          encoder=encoder, decoder=decoder)
 
-        if isinstance(secret_key, str):
-            pass
-        elif isinstance(secret_key, (bytes, bytearray)):
-            secret_key = base64.urlsafe_b64encode(secret_key)
-        self._fernet = fernet.Fernet(secret_key)
+        if isinstance(secret_key, fernet.Fernet):
+            self._fernet = secret_key
+        else:
+            if isinstance(secret_key, str):
+                pass
+            elif isinstance(secret_key, (bytes, bytearray)):
+                secret_key = base64.urlsafe_b64encode(secret_key)
+            self._fernet = fernet.Fernet(secret_key)
 
     async def load_session(self, request):
         cookie = self.load_cookie(request)


### PR DESCRIPTION
This avoid guesswork about whether to b64_encode the key or not.

Fixes #447.